### PR TITLE
fix(go.mod): remove comment for Scalingo installed Go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,5 @@
 module github.com/Scalingo/sample-go-gin
 
-// +scalingo goVersion go1.17
 go 1.19
 
 require github.com/gin-gonic/gin v1.8.2


### PR DESCRIPTION
The Go buildpack is able to read the Go version from the go.mod file.