### PR TITLE
feat: upgrade the go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.2
+FROM golang:1.26.5
 
 RUN go install github.com/cespare/reflex@latest
 ADD . /go/src/github.com/Scalingo/sample-go-gin

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Scalingo/sample-go-gin
 
-go 1.26.0
+go 1.26.5
 
 require github.com/gin-gonic/gin v1.12.0
 


### PR DESCRIPTION
This PR permit to upgrade the go version to 1.26.5

test: https://samirgotest.osc-fr1.scalingo.io/